### PR TITLE
Empty sheet in Firefox 11.0 (Ubuntu)

### DIFF
--- a/jquery.printPage.js
+++ b/jquery.printPage.js
@@ -66,7 +66,7 @@
      */
     var components = {
       iframe: function(url){
-        return '<iframe id="printPage" name="printPage" src='+url+' style="position:absolute;top:0px; left:0px;width:0px; height:0px;border:0px;overfow:none; z-index:-1"></iframe>';
+        return '<iframe id="printPage" name="printPage" src='+url+' style="position:absolute;top:-9999px;left:-9999px;border:0px;overfow:none; z-index:-1"></iframe>';
       },
       messageBox: function(message){
         return "<div id='printMessageBox' style='\


### PR DESCRIPTION
In Firefox 11.0 (Ubuntu) if printing only image by url, the print sheet is empty. The Chrome 17 works in both cases. Didn't check it in Safari and IE.
