### PR TITLE
['printPage'] is better written in dot notation.

### DIFF
--- a/jquery.printPage.js
+++ b/jquery.printPage.js
@@ -56,8 +56,8 @@
      * Call the print browser functionnality, focus is needed for IE
      */
     function printit(){
-      frames["printPage"].focus();
-      frames["printPage"].print();
+      frames.printPage.focus();
+      frames.printPage.print();
       if(pluginOptions.showMessage){
         unloadMessage();
       }


### PR DESCRIPTION
http://jslinterrors.com/a-is-better-written-in-dot-notation/
